### PR TITLE
fix insert if node gets split

### DIFF
--- a/lib/btree.js
+++ b/lib/btree.js
@@ -81,9 +81,11 @@ Node.prototype.insert = function(key, value) {
 
     if (child.isFull()) {
       this.split(i)
-    }
 
-    child.insert(key, value)
+      this.insert(key, value)
+    } else {
+      child.insert(key, value)
+    }
   }
 }
 

--- a/test/btree_test.js
+++ b/test/btree_test.js
@@ -8,6 +8,18 @@ describe('BTree', function() {
 
   // Based on example on http://www.cs.utexas.edu/users/djimenez/utsa/cs3343/lecture17.html
 
+  it('sequential insert 6+ elements', function () {
+    var tree = new BTree()
+    tree.insert(1, 1)
+    tree.insert(2, 2)
+    tree.insert(3, 3)
+    tree.insert(4, 4)
+    tree.insert(5, 5)
+    tree.insert(6, 6)
+
+    assert.equal(tree.search(6), 6)
+  })
+
   it('insert 5', function () {
     this.tree.insert(5, 5)
 
@@ -98,7 +110,7 @@ describe('BTree', function() {
       it('search for ' + i, function() {
         assert.equal(this.tree.search(i), i)
       })
-      
+
     })(i)
   }
 })


### PR DESCRIPTION
There's a little bug on insertions. If you do.

tree.insert(1,1)
tree.insert(2,2)
tree.insert(3,3)
tree.insert(4,4)
tree.insert(5,5)
tree.insert(6,6)

tree.find(6) -> won't find anything

tree.insert(7,7)
tree.insert(8,8)

-> it will find 7, and 8 fine, but won't find 9

tree.insert(9,9)
tree.search(9) -> undefined
